### PR TITLE
add a token setting for colorizing based on rotation

### DIFF
--- a/assets/js/classes/CharacterToken.js
+++ b/assets/js/classes/CharacterToken.js
@@ -454,6 +454,7 @@ export default class CharacterToken extends Token {
 
         const {
             name,
+            team,
             image,
             reminders = [],
             remindersGlobal = [],
@@ -463,6 +464,9 @@ export default class CharacterToken extends Token {
         } = this.data;
 
         return this.constructor.templates.token.draw({
+            ".js--character"(element) {
+                element.dataset.team = team;
+            },
             ".js--character--leaves"(element) {
 
                 element.classList.toggle("character--setup", setup);
@@ -473,7 +477,15 @@ export default class CharacterToken extends Token {
 
             },
             ".js--character--image"(element) {
+
                 element.src = image;
+
+                // For colorization purposes, duplicate traveller images on character icons.
+                // They are positioned absolute, so they'll render on top of each other.
+                if (team === 'traveller') {
+                    element.parentNode.appendChild(element.cloneNode());
+                }
+
             },
             ".js--character--name"(element) {
                 element.textContent = name;

--- a/assets/js/processes/grimoire/general.js
+++ b/assets/js/processes/grimoire/general.js
@@ -82,6 +82,14 @@ lookupOne("#show-night-order").addEventListener("change", ({ target }) => {
 
 });
 
+const colorizeToggle = lookupOne("#colorize-tokens");
+colorizeToggle.addEventListener("change", ({ target }) => {
+
+    padElement.classList.toggle('colorize', target.checked);
+
+});
+padElement.classList.toggle('colorize', colorizeToggle.checked);
+
 gameObserver.on("clear", () => pad.reset());
 
 // Character and Reminder token sizes.

--- a/assets/scss/components/_character-reminder.scss
+++ b/assets/scss/components/_character-reminder.scss
@@ -51,7 +51,7 @@
     }
 
     &.is-dead {
-        filter: grayscale(1) brightness(0.8);
+        filter: brightness(0.5);
     }
 }
 
@@ -139,6 +139,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    position: relative;
 }
 
 .character__shroud {
@@ -182,6 +183,7 @@
     width: 90%;
     aspect-ratio: 1/1;
     object-fit: contain;
+    position: absolute;
 }
 
 .character__name {

--- a/assets/scss/components/_token.scss
+++ b/assets/scss/components/_token.scss
@@ -52,6 +52,50 @@
     }
 }
 
+// Colorization of tokens based on rotated state.
+.colorize .token .character {
+    // Filter values for converting from one team color to the other.
+    --blue-to-red: hue-rotate(162deg) brightness(0.7) saturate(1.7);
+    --red-to-blue: hue-rotate(237deg) brightness(1.8);
+
+    // Travellers render two images for colorization.
+    // One we'll use for the left half, and one for the right half.
+    &:is([data-team=traveller i]) .character__icon {
+        &:first-of-type {
+            clip-path: inset(0 50% 0 0);
+        }
+        &:last-of-type {
+            clip-path: inset(0 0 0 50%);
+        }
+    }
+
+    &:not(.is-upside-down) {
+        // Colorize traveller tokens as fully blue if un-rotated (second image).
+        &:is([data-team=traveller i]) .character__icon:last-of-type {
+            filter: var(--red-to-blue);
+        }
+    }
+    &.is-upside-down {
+        --shadow-rotation: -1;
+        transform: rotate(180deg);
+
+        // Colorize rotated townsfolk and outsiders as red.
+        &:is([data-team=townsfolk i], [data-team=outsider i]) .character__icon {
+            filter: var(--blue-to-red);
+        }
+
+        // Colorize rotated demons and minions as blue.
+        &:is([data-team=demon i], [data-team=minion i]) .character__icon {
+            filter: var(--red-to-blue);
+        }
+
+        // Colorize traveller tokens as fully red if rotated (first image).
+        &:is([data-team=traveller i]) .character__icon:first-of-type {
+            filter: var(--blue-to-red);
+        }
+    }
+}
+
 .token--movable {
     --left: 0;
     --top: 0;

--- a/templates/partials/grimoire.html.twig
+++ b/templates/partials/grimoire.html.twig
@@ -36,6 +36,16 @@
             </div>
 
             <div class="mt-4">
+                {{ forms.switch({
+                    node: 'div',
+                    label: 'grimoire.grimoire.colorize_tokens'|trans,
+                    name: 'colorize-tokens',
+                    id: 'colorize-tokens',
+                    checked: true
+                }) }}
+            </div>
+
+            <div class="mt-4">
                 {{ forms.range({
                     label: 'grimoire.grimoire.character_size'|trans,
                     name: 'token-size',

--- a/translations/messages.en_GB.yaml
+++ b/translations/messages.en_GB.yaml
@@ -143,6 +143,7 @@ grimoire:
         clear_grimoire: Clear Grimoire
         clear_grimoire_warning: Are you sure you want to clear all the tokens?
         show_night_order: Show night order
+        colorize_tokens: Colorize tokens
         character_size: Character token size
         reminder_size: Reminder token size
         token_settings: Token Settings


### PR DESCRIPTION
This is a nice little quality-of-life feature I wish I had while I was running my game the other night!

- Adds a new "Colorize tokens" toggle in the Token Settings panel, defaulted to on. ![image](https://github.com/user-attachments/assets/3c400b8c-61d4-4c31-94ac-f4a0590c449e)

- When the toggle is **disabled**, tokens look like they do normally: ![image](https://github.com/user-attachments/assets/62c317ae-eda9-4823-bbc4-232199667c97)

- When the toggle is **enabled**, tokens are colored based on their current rotation. Good tokens become red, evil tokens become blue, and travelers are full-blue if rightside-up and full-red if upside-down. ![image](https://github.com/user-attachments/assets/eee0ca52-876b-403a-b01f-82d7c6b8a619)

- Also updated the dead state of tokens to simply darken without grayscale - this way you can see which color the tokens are underneath the shroud: ![image](https://github.com/user-attachments/assets/2eda2abe-5e72-4743-be14-12f162db3550)

- Also note this new toggle has no effect on fabled characters or reminder tokens: 
![image](https://github.com/user-attachments/assets/4800403f-b2de-464d-a97d-6c8ca4b3e35c)
