### PR TITLE
Add inverted ellipse layout

### DIFF
--- a/assets/js/classes/Positioner.js
+++ b/assets/js/classes/Positioner.js
@@ -49,6 +49,26 @@ export default class Positioner {
 
         },
 
+        ellipseInverted(data) {
+            const { total } = data;
+
+            const tempData = {
+                ...data,
+                total: 2*total
+            };
+
+            const ellipseCoordsX2 = Positioner.layouts.ellipse(tempData);
+
+            const coordinates = [];
+
+            times(total, (index) => {
+                coordinates.push(ellipseCoordsX2[(total+1+2*index) % (2*total)])
+            });
+            
+            return coordinates;
+
+        },
+
         diagonal(data) {
 
             const {

--- a/templates/partials/setup/select-characters.html.twig
+++ b/templates/partials/setup/select-characters.html.twig
@@ -92,6 +92,7 @@
             <label for="token-layout">{{ 'setup.character_select.layout'|trans }}</label>
             <select name="token-layout" id="token-layout" class="input">
                 <option value="ellipse">{{ 'setup.character_select.ellipse'|trans }}</option>
+                <option value="ellipseInverted">{{ 'setup.character_select.ellipse_inverted'|trans }}</option>
                 <option value="diagonal">{{ 'setup.character_select.diagonal'|trans }}</option>
                 <option value="horizontal">{{ 'setup.character_select.horizontal'|trans }}</option>
                 <option value="vertical">{{ 'setup.character_select.vertical'|trans }}</option>

--- a/translations/messages.de_DE.yaml
+++ b/translations/messages.de_DE.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Alle hinzufügen
         layout: Anordnung
         ellipse: Ellipse
+        ellipse_inverted: Ellipse (Invertiert)
         diagonal: Diagonal
         horizontal: Horizontal
         vertical: Vertikal

--- a/translations/messages.en_GB.yaml
+++ b/translations/messages.en_GB.yaml
@@ -80,6 +80,7 @@ setup:
         add_all: Add All
         layout: Layout
         ellipse: Ellipse
+        ellipse_inverted: Ellipse (Inverted)
         diagonal: Diagonal
         horizontal: Horizontal
         vertical: Vertical

--- a/translations/messages.es_AR.yaml
+++ b/translations/messages.es_AR.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Agregar Todos
         layout: Disposición
         ellipse: Elipse
+        ellipse_inverted: Elipse (Invertida)
         diagonal: Diagonal
         horizontal: Horizontal
         vertical: Vertical

--- a/translations/messages.es_ES.yaml
+++ b/translations/messages.es_ES.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Agregar Todos
         layout: Disposición
         ellipse: Elipse
+        ellipse_inverted: Elipse (Invertida)
         diagonal: Diagonal
         horizontal: Horizontal
         vertical: Vertical

--- a/translations/messages.fr_FR.yaml
+++ b/translations/messages.fr_FR.yaml
@@ -80,6 +80,7 @@ setup:
         add_all: Tout Ajouter
         layout: Mise en page
         ellipse: Ellipse
+        ellipse_inverted: Ellipse (Inversée)
         diagonal: Diagonale
         horizontal: Horizontal
         vertical: Verticale

--- a/translations/messages.he_IL.yaml
+++ b/translations/messages.he_IL.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: הוסף הכל
         layout: מַעֲרָך
         ellipse: אֶלִיפְּסָה
+        ellipse_inverted: אֶלִיפְּסָה (הפוך)
         diagonal: אֲלַכסוֹנִי
         horizontal: אופקי
         vertical: אֲנָכִי

--- a/translations/messages.id_ID.yaml
+++ b/translations/messages.id_ID.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Tambah Semua
         layout: Layout
         ellipse: Ellipse
+        ellipse_inverted: Ellipse (Terbalik)
         diagonal: Diagonal
         horizontal: Horizontal
         vertical: Vertikal

--- a/translations/messages.it_IT.yaml
+++ b/translations/messages.it_IT.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Aggiungi tutti
         layout: Layout
         ellipse: Ellisse
+        ellipse_inverted: Ellisse (Invertita)
         diagonal: Diagonale
         horizontal: Orizzontale
         vertical: Verticale

--- a/translations/messages.ja_JP.yaml
+++ b/translations/messages.ja_JP.yaml
@@ -80,6 +80,7 @@ setup:
         add_all: 全て追加
         layout: レイアウト
         ellipse: 楕円
+        ellipse_inverted: 楕円（反転）
         diagonal: 対角線
         horizontal: 水平
         vertical: 垂直

--- a/translations/messages.ko_KR.yaml
+++ b/translations/messages.ko_KR.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: 모두 추가
         layout: 레이아웃
         ellipse: 타원
+        ellipse_inverted: 타원(역타원)
         diagonal: 대각선
         horizontal: 수평
         vertical: 수직

--- a/translations/messages.kv_RU.yaml
+++ b/translations/messages.kv_RU.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Добавить все
         layout: Расположение
         ellipse: По кругу
+        ellipse_inverted: По кругу (перевернутом)
         diagonal: По диагонали
         horizontal: Горизонтально
         vertical: Вертикально

--- a/translations/messages.nb_NO.yaml
+++ b/translations/messages.nb_NO.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Legg til alle
         layout: Oppsett
         ellipse: Ellipse
+        ellipse_inverted: Ellipse (Invertert)
         diagonal: Diagonalt
         horizontal: Horisontalt
         vertical: Vertikalt

--- a/translations/messages.nn_NO.yaml
+++ b/translations/messages.nn_NO.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Legg til alle
         layout: Oppsett
         ellipse: Ellipse
+        ellipse_inverted: Ellipse (Invertert)
         diagonal: Diagonalt
         horizontal: Horisontalt
         vertical: Vertikalt

--- a/translations/messages.pl_PL.yaml
+++ b/translations/messages.pl_PL.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Dodaj wszystko
         layout: Układ
         ellipse: Elipsa
+        ellipse_inverted: Elipsa (Odwrócona)
         diagonal: Przekątna
         horizontal: Poziomo
         vertical: Pionowo

--- a/translations/messages.pt_BR.yaml
+++ b/translations/messages.pt_BR.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Adicionar tudo
         layout: Disposição
         ellipse: Elipse
+        ellipse_inverted: Elipse (Invertida)
         diagonal: Diagonal
         horizontal: Horizontal
         vertical: Vertical

--- a/translations/messages.ru_RU.yaml
+++ b/translations/messages.ru_RU.yaml
@@ -80,6 +80,7 @@ setup:
         add_all: Добавить все
         layout: Макет
         ellipse: Эллипс
+        ellipse_inverted: Эллипс (перевернутый)
         diagonal: Диагональ
         horizontal: Горизонтальный
         vertical: Вертикальный

--- a/translations/messages.sl_SI.yaml
+++ b/translations/messages.sl_SI.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Dodaj vse
         layout: Oblika
         ellipse: Elipsa
+        ellipse_inverted: Elipsa (Obrnjena)
         diagonal: Diagonala
         horizontal: Navpičnica
         vertical: Vodoravnica

--- a/translations/messages.sv_SE.yaml
+++ b/translations/messages.sv_SE.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Lägg till alla
         layout: Layout
         ellipse: Elliptisk
+        ellipse_inverted: Elliptisk (Inverterad)
         diagonal: Diagonal
         horizontal: Horisontell
         vertical: Vertikal

--- a/translations/messages.th_TH.yaml
+++ b/translations/messages.th_TH.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: เพิ่มตัวละครที่เลือกลงในกรีมัวร์
         layout: การจัดวาง
         ellipse: วงรี
+        ellipse_inverted: วงรี (กลับหัว)
         diagonal: แนวทแยงมุม
         horizontal: แนวนอน
         vertical: แนวตั้ง

--- a/translations/messages.tr_TR.yaml
+++ b/translations/messages.tr_TR.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Hepsini Ekle
         layout: Düzen
         ellipse: Elips
+        ellipse_inverted: Elips (Ters)
         diagonal: Diyagonal
         horizontal: Yatay
         vertical: Dikey

--- a/translations/messages.uk_UA.yaml
+++ b/translations/messages.uk_UA.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Додати Усіх
         layout: Розташування
         ellipse: Еліпс
+        ellipse_inverted: Еліпс (перевернутий)
         diagonal: Діагонально
         horizontal: Горизонтально
         vertical: Вертикально

--- a/translations/messages.vi_VI.yaml
+++ b/translations/messages.vi_VI.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: Thêm tất cả
         layout: Cách trình bày
         ellipse: hình elip
+        ellipse_inverted: hình elip (đảo ngược)
         diagonal: Đường chéo
         horizontal: Nằm ngang
         vertical: Thẳng đứng

--- a/translations/messages.zh_CN.yaml
+++ b/translations/messages.zh_CN.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: 全部添加
         layout: 布局
         ellipse: 椭圆
+        ellipse_inverted: 椭圆（倒置）
         diagonal: 对角线
         horizontal: 水平
         vertical: 垂直

--- a/translations/messages.zh_TW.yaml
+++ b/translations/messages.zh_TW.yaml
@@ -79,6 +79,7 @@ setup:
         add_all: 全部添加
         layout: 角色代幣佈局
         ellipse: 橢圓
+        ellipse_inverted: 橢圓（倒置）
         diagonal: 對角線
         horizontal: 水平
         vertical: 垂直


### PR DESCRIPTION
Add a new layout where storyteller position is in the middle of the bottom of the grimoire. Add machine translations for new layout name.

Partially addresses [#104 ](https://github.com/Skateside/pocket-grimoire/issues/104). In particular, it covers the case discussed in the linked Discord message. I have also had friends IRL mention that they would prefer this sort of layout.

This is my first time creating a PR for a project like this, so please let me know if I have made any mistakes.