### PR TITLE
Show player names next to roles in night order lists

### DIFF
--- a/assets/js/classes/NightOrder.js
+++ b/assets/js/classes/NightOrder.js
@@ -126,6 +126,7 @@ export default class NightOrder {
             character,
             alive: 0,
             inPlay: 0,
+            playerNames: new Map(),
         };
         const firstNight = character.getFirstNight();
         const otherNight = character.getOtherNight();
@@ -561,6 +562,88 @@ export default class NightOrder {
      */
     adjustInPlay(data, quantity) {
         data.inPlay = Math.max(0, data.inPlay + quantity);
+    }
+
+    /**
+     * Sets the player name for a given character's token in the night order.
+     *
+     * @param {CharacterToken} character
+     *        The character whose player name should be updated.
+     * @param {Element} token
+     *        The token element used as a key for tracking the name.
+     * @param {String} name
+     *        The player name to display.
+     */
+    setPlayerName(character, token, name) {
+
+        const index = this.getDataIndex(character);
+
+        if (index < 0) {
+            return;
+        }
+
+        const data = this.data[index];
+
+        if (name) {
+            data.playerNames.set(token, name);
+        } else {
+            data.playerNames.delete(token);
+        }
+
+        this.updatePlayerNameDisplay(data);
+
+    }
+
+    /**
+     * Removes the player name associated with a specific token element.
+     *
+     * @param {CharacterToken} character
+     *        The character whose player name should be removed.
+     * @param {Element} token
+     *        The token element whose name should be removed.
+     */
+    removePlayerName(character, token) {
+
+        const index = this.getDataIndex(character);
+
+        if (index < 0) {
+            return;
+        }
+
+        const data = this.data[index];
+        data.playerNames.delete(token);
+        this.updatePlayerNameDisplay(data);
+
+    }
+
+    /**
+     * Updates the player name display in both night order lists for the given
+     * data entry.
+     *
+     * @param {Object} data
+     *        The data entry to update.
+     */
+    updatePlayerNameDisplay(data) {
+
+        const names = [...data.playerNames.values()].filter(Boolean);
+        const display = names.join(", ");
+
+        ["first", "other"].forEach((property) => {
+
+            if (!data[property]) {
+                return;
+            }
+
+            const element = data[property].element.querySelector(
+                ".js--night-info--player-name"
+            );
+
+            if (element) {
+                element.textContent = display;
+            }
+
+        });
+
     }
 
 }

--- a/assets/js/processes/night-order.js
+++ b/assets/js/processes/night-order.js
@@ -109,6 +109,7 @@ tokenObserver.on("character-remove", ({ detail }) => {
         return;
     }
 
+    nightOrder.removePlayerName(character, detail.token);
     nightOrder.removeCharacter(character);
 
 });
@@ -121,6 +122,16 @@ tokenObserver.on("shroud-toggle", ({ detail }) => {
     }
 
     nightOrder.toggleDead(detail.character, detail.isDead);
+
+});
+
+tokenObserver.on("set-player-name", ({ detail }) => {
+
+    if (!nightOrder.hasCharacter(detail.character)) {
+        return;
+    }
+
+    nightOrder.setPlayerName(detail.character, detail.token, detail.name);
 
 });
 

--- a/assets/scss/components/_night-order.scss
+++ b/assets/scss/components/_night-order.scss
@@ -41,6 +41,22 @@
     flex-grow: 1;
 }
 
+.night-order__player-name {
+    margin: 0;
+    font-size: 0.85em;
+    opacity: 0.7;
+    font-style: italic;
+    white-space: nowrap;
+
+    &:empty {
+        display: none;
+    }
+
+    &::before {
+        content: "\2014\00a0";
+    }
+}
+
 .night-order__ability {
     font-size: 0.8em;
     margin: 0;

--- a/templates/partials/night-order.html.twig
+++ b/templates/partials/night-order.html.twig
@@ -43,6 +43,7 @@
                 <img src="" alt="" class="night-order__icon js--night-info--icon" loading="lazy">
             </div>
             <p class="night-order__role js--night-info--role"></p>
+            <span class="night-order__player-name js--night-info--player-name"></span>
         </div>
         <p class="night-order__ability js--night-info--ability"></p>
     </li>


### PR DESCRIPTION
Closes https://github.com/Skateside/pocket-grimoire/issues/55

This PR adds names next to character roles in the night order list. This makes it much easier as a Storyteller to figure out who you need to wake up in the night without needing to keep scrolling up and down to see the Grimoire above.

<img width="302" height="506" alt="Screenshot 2026-03-20 at 3 50 19 PM" src="https://github.com/user-attachments/assets/6c514948-f479-4aff-966f-cb3c195e9f17" />

The diff is pretty straightforward, let me know if any changes are requested.